### PR TITLE
Automatically install six in codejails.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ install:
   - "sudo apt-get install python3 -y"
   - "make test.requirements"
   - "virtualenv --python=`which python3` ./py3venv"
-  - "./py3venv/bin/pip3 install six"
 script:
   - "XQUEUEWATCHER_PYTHON3_BIN=`pwd`/py3venv/bin/python3 nosetests --with-coverage --cover-package=xqueue_watcher --cover-xml"
 after_script:


### PR DESCRIPTION
[TNL-5266](https://openedx.atlassian.net/browse/TNL-5266)

## Description

Making XQueueWatcher able to handle both python2 and python3 required adding a dependency on the six library to the grader_support code.  This code gets used in the codejails that get created, which run in separate virtualenvs.  Codejail then copies the support code into the jail's working directory (which is apparmored, and deleted after use).  

So now, we need to either 

* manually pip-install six in every jailed virtualenv, or 
* add six to the list of code that codejail pulls into its jails.  

In order to make the grader_support code more self-contained, we opted for the latter approach.

## Reviewers: 
- [x] @maxrothman 
- [x] @sanfordstudent 

