### PR TITLE
Stop following login redirect so rapidly

### DIFF
--- a/xqueue_watcher/client.py
+++ b/xqueue_watcher/client.py
@@ -63,7 +63,14 @@ class XQueueClient(object):
         r = None
         while not r:
             try:
-                r = self.session.request(method, url, auth=self.http_basic_auth, timeout=timeout, **kwargs)
+                r = self.session.request(
+                    method,
+                    url,
+                    auth=self.http_basic_auth,
+                    timeout=timeout,
+                    allow_redirects=False,
+                    **kwargs
+                )
             except requests.exceptions.ConnectionError as e:
                 log.error('Could not connect to server at %s in timeout=%r', url, timeout)
                 return (False, e.message)


### PR DESCRIPTION
# [TNL-5928](https://openedx.atlassian.net/browse/TNL-5928)

There's code here designed to handle a login-requested event, let's
use it.

Previously, xqueue would respond with a 302 that was immediately
followed (by the requests library under-the-hood) to the /login
URL, but with the exact same parameters. For some reason, this
led to a 200 response containing parseable json, so this code
block had no idea and was unable to fix the problem.

Source on the previous default behavior of following redirects: http://docs.python-requests.org/en/latest/user/quickstart/#redirection-and-history

@jcdyer and @jibsheet to review. I'm still unsure why clients are being logged out in the first place, but this change will allow xqueue-watcher to utilize the "302 login required" logic it already contains and solve the problem for end users, at least.

The reason I came to this conclusion is that there are many, many request pairs in splunk that look like this:
- `1/29/17 1:08:59.000 PM DEBUG:requests.packages.urllib3.connectionpool:"GET /xqueue/get_submission/?queue_name=MITx-7.QBWx&block=true HTTP/1.1" 302 0`
- `1/29/17 1:08:59.000 PM DEBUG:requests.packages.urllib3.connectionpool:"GET /xqueue/login/?next=/xqueue/get_submission/%3Fqueue_name%3DMITx-7.QBWx%26block%3Dtrue HTTP/1.1" 200 66`

Note that these are all coming from `requests.packages.urllib3.connectionpool`, not `xqueue_watcher.client` as seen in all the `log.error()` calls in the file I've modified. How else could we have gotten from the `self.session.request` call in line 66 to the end of the `_request` method without hitting any logging lines?

I'm hypothesizing that the 200 response we're seeing from the `/login` redirect request is some sort of "well technically the page loaded, but really you shouldn't be using a GET request against this URL" message.

The reason restarting xqueue-watcher was able to fix the issue is that the initial login code (which is the same as the soon-to-be re-login after expiry code) will correctly make a POST request at `/login` with the proper parameters.