### PR TITLE
set OPENBLAS_NUM_THREADS enviornment variable

### DIFF
--- a/xqueue_watcher/jailedgrader.py
+++ b/xqueue_watcher/jailedgrader.py
@@ -1,6 +1,7 @@
 """
 An implementation of a grader that uses codejail to sandbox submission execution.
 """
+import os
 import sys
 import imp
 import json
@@ -67,6 +68,8 @@ class JailedGrader(Grader):
         super(JailedGrader, self).__init__(*args, **kwargs)
         self.locale_dir = self.grader_root / "conf" / "locale"
         self.fork_per_item = False  # it's probably safe not to fork
+        # EDUCATOR-3368: OpenBLAS library is allowed to allocate 1 thread
+        os.environ["OPENBLAS_NUM_THREADS"] = "1"
 
     def _enable_i18n(self, language):
         trans = gettext.translation('graders', localedir=self.locale_dir, fallback=True, languages=[language])


### PR DESCRIPTION
## [EDUCATOR-3368](https://openedx.atlassian.net/browse/EDUCATOR-3368)

### Description

During investigation of issue filed in [EDUCATOR-3298](https://openedx.atlassian.net/browse/EDUCATOR-3298) it was revealed that 

> OpenBLAS library that NumPy relies on attempts to allocate more system resources at startup then apparmor is configured to allow.

Suggested solution to restrict allocation of resources within apparmor allowed range is adding OPENBLAS_NUM_THREADS environment variable with value set to 1. 

