### PR TITLE
Removed usages of package six

### DIFF
--- a/grader_support/gradelib.py
+++ b/grader_support/gradelib.py
@@ -5,7 +5,7 @@ import re
 import sys
 import tokenize
 
-import six
+from io import BytesIO, StringIO
 # the run library should overwrite this with a particular random seed for the test.
 rand = random.Random(1)
 
@@ -239,10 +239,10 @@ def _tokens(code):
     """
     # Protect against pathological inputs: http://bugs.python.org/issue16152
     code = code.rstrip() + "\n"
-    if isinstance(code, six.text_type):
+    if isinstance(code, str):
         code = code.encode('utf8')
     code = "# coding: utf8\n" + code
-    toks = tokenize.generate_tokens(six.BytesIO(code).readline)
+    toks = tokenize.generate_tokens(BytesIO(code).readline)
     return toks
 
 def _count_tokens(code, string):
@@ -466,7 +466,7 @@ def required_class_method(class_name, method_name, error_msg=None):
 @contextlib.contextmanager
 def capture_stdout():
     old_stdout = sys.stdout
-    sys.stdout = stdout = six.StringIO()
+    sys.stdout = stdout = StringIO()
     yield stdout
     sys.stdout = old_stdout
 
@@ -481,7 +481,7 @@ def exec_wrapped_code(environment=None, post_process=None):
         environment = {}
     def test_fn(submission_module):
         with capture_stdout() as stdout:
-            six.exec_(submission_module.submission_code, environment)
+            exec(submission_module.submission_code, environment)
         stdout_text = stdout.getvalue()
         if post_process:
             stdout_text = post_process(stdout_text)
@@ -503,7 +503,7 @@ def exec_code_and_inspect_values(environment=None, vars_to_inspect=None, post_pr
         environment = {}
     def test_fn(submission_module):
         with capture_stdout() as stdout:
-            six.exec_(submission_module.submission_code, environment)
+            exec(submission_module.submission_code, environment)
 
         for var in vars_to_inspect:
             print(var)
@@ -530,7 +530,7 @@ def invoke_student_function(fn_name, args, environment=None, output_writer=None)
     """
     output_writer = output_writer or repr
     def doit(submission_module):
-        for name, value in six.iteritems(environment or {}):
+        for name, value in (environment or {}).items():
             setattr(submission_module, name, value)
         fn = getattr(submission_module, fn_name)
         print(output_writer(fn(*args)))

--- a/grader_support/graderutil.py
+++ b/grader_support/graderutil.py
@@ -10,7 +10,7 @@ import tempfile
 import textwrap
 import traceback
 
-import six
+from io import StringIO
 
 # Set this variable to the language code you wish to use
 # Default is 'en'. Dummy translations are served up in 'eo'.
@@ -29,7 +29,7 @@ def captured_stdout():
 
     """
     old_stdout = sys.stdout
-    sys.stdout = stdout = six.StringIO()
+    sys.stdout = stdout = StringIO()
 
     try:
         yield stdout

--- a/grader_support/run.py
+++ b/grader_support/run.py
@@ -15,8 +15,6 @@ import json
 import random
 import sys
 
-import six
-
 from . import gradelib  # to set the random seed
 from . import graderutil
 
@@ -31,10 +29,7 @@ trans = gettext.translation(  # pylint: disable=invalid-name
     fallback=True,
     languages=[graderutil.LANGUAGE]
 )
-if six.PY2:
-    trans.install(names=None, unicode=True)
-else:
-    trans.install(names=None)
+trans.install(names=None)
 
 
 def run(grader_name, submission_name, seed=1):

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -6,6 +6,5 @@ dogstatsd-python
 newrelic
 path.py
 requests
-six
 
 -e git+https://github.com/edx/codejail.git@4127fc4bd5775cc72aee8d7f0a70e31405e22439#egg=codejail

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,20 +5,13 @@
 #    make upgrade
 #
 -e git+https://github.com/edx/codejail.git@4127fc4bd5775cc72aee8d7f0a70e31405e22439#egg=codejail  # via -r requirements/base.in
-backports.os==0.1.1       # via path.py
 certifi==2020.6.20        # via requests
 chardet==3.0.4            # via requests
-configparser==4.0.2       # via importlib-metadata
-contextlib2==0.6.0.post1  # via importlib-metadata, zipp
 dogstatsd-python==0.5.6   # via -r requirements/base.in
-future==0.18.2            # via backports.os
 idna==2.10                # via requests
 importlib-metadata==1.7.0  # via path.py
 newrelic==5.14.1.144      # via -r requirements/base.in
 path.py==11.5.2           # via -c requirements/constraints.txt, -r requirements/base.in
-pathlib2==2.3.5           # via importlib-metadata
 requests==2.24.0          # via -r requirements/base.in
-scandir==1.10.0           # via pathlib2
-six==1.15.0               # via -r requirements/base.in, pathlib2
 urllib3==1.25.9           # via requests
 zipp==1.2.0               # via importlib-metadata

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -5,20 +5,13 @@
 #    make upgrade
 #
 -e git+https://github.com/edx/codejail.git@4127fc4bd5775cc72aee8d7f0a70e31405e22439#egg=codejail  # via -r requirements/base.txt
-backports.os==0.1.1       # via -r requirements/base.txt, path.py
 certifi==2020.6.20        # via -r requirements/base.txt, requests
 chardet==3.0.4            # via -r requirements/base.txt, requests
-configparser==4.0.2       # via -r requirements/base.txt, importlib-metadata
-contextlib2==0.6.0.post1  # via -r requirements/base.txt, importlib-metadata, zipp
 dogstatsd-python==0.5.6   # via -r requirements/base.txt
-future==0.18.2            # via -r requirements/base.txt, backports.os
 idna==2.10                # via -r requirements/base.txt, requests
 importlib-metadata==1.7.0  # via -r requirements/base.txt, path.py
 newrelic==5.14.1.144      # via -r requirements/base.txt
 path.py==11.5.2           # via -c requirements/constraints.txt, -r requirements/base.txt
-pathlib2==2.3.5           # via -r requirements/base.txt, importlib-metadata
 requests==2.24.0          # via -r requirements/base.txt
-scandir==1.10.0           # via -r requirements/base.txt, pathlib2
-six==1.15.0               # via -r requirements/base.txt, pathlib2
 urllib3==1.25.9           # via -r requirements/base.txt, requests
 zipp==1.2.0               # via -r requirements/base.txt, importlib-metadata

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,34 +5,26 @@
 #    make upgrade
 #
 -e git+https://github.com/edx/codejail.git@4127fc4bd5775cc72aee8d7f0a70e31405e22439#egg=codejail  # via -r requirements/production.txt
-atomicwrites==1.4.0       # via pytest
 attrs==19.3.0             # via pytest
-backports.functools-lru-cache==1.6.1  # via wcwidth
-backports.os==0.1.1       # via -r requirements/production.txt, path.py
 certifi==2020.6.20        # via -r requirements/production.txt, requests
 chardet==3.0.4            # via -r requirements/production.txt, requests
-configparser==4.0.2       # via -r requirements/production.txt, importlib-metadata
-contextlib2==0.6.0.post1  # via -r requirements/production.txt, importlib-metadata, zipp
-coverage==5.1             # via pytest-cov
+coverage==5.2             # via pytest-cov
 dogstatsd-python==0.5.6   # via -r requirements/production.txt
-funcsigs==1.0.2           # via mock, pytest
-future==0.18.2            # via -r requirements/production.txt, backports.os
 idna==2.10                # via -r requirements/production.txt, requests
 importlib-metadata==1.7.0  # via -r requirements/production.txt, path.py, pluggy, pytest
 mock==3.0.5               # via -r requirements/test.in
-more-itertools==5.0.0     # via pytest
+more-itertools==8.4.0     # via pytest
 newrelic==5.14.1.144      # via -r requirements/production.txt
 packaging==20.4           # via pytest
 path.py==11.5.2           # via -c requirements/constraints.txt, -r requirements/production.txt
-pathlib2==2.3.5           # via -r requirements/production.txt, importlib-metadata, pytest
+pathlib2==2.3.5           # via pytest
 pluggy==0.13.1            # via pytest
 py==1.9.0                 # via pytest
 pyparsing==2.4.7          # via packaging
 pytest-cov==2.10.0        # via -r requirements/test.in
-pytest==4.6.11            # via pytest-cov
+pytest==5.4.3             # via pytest-cov
 requests==2.24.0          # via -r requirements/production.txt
-scandir==1.10.0           # via -r requirements/production.txt, pathlib2
-six==1.15.0               # via -r requirements/production.txt, mock, more-itertools, packaging, pathlib2, pytest
+six==1.15.0               # via mock, packaging, pathlib2
 urllib3==1.25.9           # via -r requirements/production.txt, requests
 wcwidth==0.2.5            # via pytest
 zipp==1.2.0               # via -r requirements/production.txt, importlib-metadata

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -5,34 +5,26 @@
 #    make upgrade
 #
 -e git+https://github.com/edx/codejail.git@4127fc4bd5775cc72aee8d7f0a70e31405e22439#egg=codejail  # via -r requirements/test.txt
-atomicwrites==1.4.0       # via -r requirements/test.txt, pytest
 attrs==19.3.0             # via -r requirements/test.txt, pytest
-backports.functools-lru-cache==1.6.1  # via -r requirements/test.txt, wcwidth
-backports.os==0.1.1       # via -r requirements/test.txt, path.py
 certifi==2020.6.20        # via -r requirements/test.txt, requests
 chardet==3.0.4            # via -r requirements/test.txt, requests
-configparser==4.0.2       # via -r requirements/test.txt, importlib-metadata
-contextlib2==0.6.0.post1  # via -r requirements/test.txt, importlib-metadata, zipp
-coverage==5.1             # via -r requirements/test.txt, -r requirements/travis.in, pytest-cov
+coverage==5.2             # via -r requirements/test.txt, -r requirements/travis.in, pytest-cov
 dogstatsd-python==0.5.6   # via -r requirements/test.txt
-funcsigs==1.0.2           # via -r requirements/test.txt, mock, pytest
-future==0.18.2            # via -r requirements/test.txt, backports.os
 idna==2.10                # via -r requirements/test.txt, requests
 importlib-metadata==1.7.0  # via -r requirements/test.txt, path.py, pluggy, pytest
 mock==3.0.5               # via -r requirements/test.txt
-more-itertools==5.0.0     # via -r requirements/test.txt, pytest
+more-itertools==8.4.0     # via -r requirements/test.txt, pytest
 newrelic==5.14.1.144      # via -r requirements/test.txt
 packaging==20.4           # via -r requirements/test.txt, pytest
 path.py==11.5.2           # via -c requirements/constraints.txt, -r requirements/test.txt
-pathlib2==2.3.5           # via -r requirements/test.txt, importlib-metadata, pytest
+pathlib2==2.3.5           # via -r requirements/test.txt, pytest
 pluggy==0.13.1            # via -r requirements/test.txt, pytest
 py==1.9.0                 # via -r requirements/test.txt, pytest
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
 pytest-cov==2.10.0        # via -r requirements/test.txt
-pytest==4.6.11            # via -r requirements/test.txt, pytest-cov
+pytest==5.4.3             # via -r requirements/test.txt, pytest-cov
 requests==2.24.0          # via -r requirements/test.txt
-scandir==1.10.0           # via -r requirements/test.txt, pathlib2
-six==1.15.0               # via -r requirements/test.txt, mock, more-itertools, packaging, pathlib2, pytest
+six==1.15.0               # via -r requirements/test.txt, mock, packaging, pathlib2
 urllib3==1.25.9           # via -r requirements/test.txt, requests
 wcwidth==0.2.5            # via -r requirements/test.txt, pytest
 zipp==1.2.0               # via -r requirements/test.txt, importlib-metadata

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='xqueue_watcher',
-    version='0.2',
+    version='0.3',
     description='XQueue Pull Grader',
     packages=[
         'xqueue_watcher',

--- a/tests/test_grader.py
+++ b/tests/test_grader.py
@@ -3,7 +3,7 @@ import mock
 import json
 import sys
 from path import Path
-from six.moves.queue import Queue
+from queue import Queue
 
 from xqueue_watcher import grader
 

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -9,7 +9,7 @@ import logging
 from xqueue_watcher import manager
 from tests.test_xqueue_client import MockXQueueServer
 
-from six import StringIO
+from io import StringIO
 
 try:
     import codejail

--- a/xqueue_watcher/jailedgrader.py
+++ b/xqueue_watcher/jailedgrader.py
@@ -9,7 +9,6 @@ import json
 import random
 import gettext
 from path import Path
-import six
 
 import codejail
 
@@ -18,25 +17,12 @@ from grader_support.graderutil import LANGUAGE
 import grader_support
 
 from .grader import Grader
-from six.moves import zip
 
 TIMEOUT = 1
-
-def path_to_six():
-    """
-    Return the full path to six.py
-    """
-    if any(six.__file__.endswith(suffix) for suffix in ('.pyc', '.pyo')):
-        # __file__ points to the compiled bytecode in python 2
-        return Path(six.__file__[:-1])
-    else:
-        # __file__ points to the .py file in python 3
-        return Path(six.__file__)
 
 
 SUPPORT_FILES = [
     Path(grader_support.__file__).dirname(),
-    path_to_six(),
 ]
 
 
@@ -87,7 +73,7 @@ class JailedGrader(Grader):
         return r
 
     def grade(self, grader_path, grader_config, submission):
-        if type(submission) != six.text_type:
+        if type(submission) != str:
             self.log.warning("Submission is NOT unicode")
 
         results = {
@@ -123,7 +109,7 @@ class JailedGrader(Grader):
         # Import the grader, straight from the original file.  (It probably isn't in
         # sys.path, and we may be in a long running gunicorn process, so we don't
         # want to add stuff to sys.path either.)
-        grader_module = imp.load_source("grader_module", six.text_type(grader_path))
+        grader_module = imp.load_source("grader_module", str(grader_path))
         grader = grader_module.grader
 
         # Preprocess for grader-specified errors

--- a/xqueue_watcher/manager.py
+++ b/xqueue_watcher/manager.py
@@ -13,7 +13,6 @@ import time
 from codejail import jail_code
 
 from .settings import get_manager_config_values, MANAGER_CONFIG_DEFAULTS
-from six.moves import range
 
 
 class Manager(object):


### PR DESCRIPTION
**Issue:** [BOM-1871](https://openedx.atlassian.net/browse/BOM-1871)

### Description
- `six` is no longer necessary after moving from `python2` to `python3` so removed all of its usages.