### PR TITLE
Add alias for gettext as underscore to fix graders with translated msgs.

### DIFF
--- a/grader_support/run.py
+++ b/grader_support/run.py
@@ -30,6 +30,7 @@ trans = gettext.translation(  # pylint: disable=invalid-name
     fallback=True,
     languages=[graderutil.LANGUAGE]
 )
+_ = trans.gettext
 trans.install(names=None)
 
 


### PR DESCRIPTION
https://edx-internal.slack.com/archives/CM4RPEYEQ/p1617807575270200

Fixes errors like this:
```
 File "/edx/app/xqwatcher/data/MITx-6.00x/graders/python3graders/ps04/isValidWord/grade_isValidWord.py", line 11, in <module>
    error_msg=_("This function shouldn't use the function 'updateHand' - "
TypeError: 'int' object is not callable
```
