### PR TITLE
BOM-2474: Upgrade code to Python38

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - 3.5
   - 3.8
 install:
   - make travis.requirements

--- a/grader_support/gradelib.py
+++ b/grader_support/gradelib.py
@@ -4,9 +4,8 @@ import random
 import re
 import sys
 from tokenize import tokenize, COMMENT, STRING
-from io import BytesIO
+from io import BytesIO, StringIO
 
-import six
 # the run library should overwrite this with a particular random seed for the test.
 rand = random.Random(1)
 
@@ -463,7 +462,7 @@ def required_class_method(class_name, method_name, error_msg=None):
 @contextlib.contextmanager
 def capture_stdout():
     old_stdout = sys.stdout
-    sys.stdout = stdout = six.StringIO()
+    sys.stdout = stdout = StringIO()
     yield stdout
     sys.stdout = old_stdout
 

--- a/grader_support/graderutil.py
+++ b/grader_support/graderutil.py
@@ -10,7 +10,7 @@ import tempfile
 import textwrap
 import traceback
 
-import six
+import io
 
 # Set this variable to the language code you wish to use
 # Default is 'en'. Dummy translations are served up in 'eo'.
@@ -29,7 +29,7 @@ def captured_stdout():
 
     """
     old_stdout = sys.stdout
-    sys.stdout = stdout = six.StringIO()
+    sys.stdout = stdout = io.StringIO()
 
     try:
         yield stdout

--- a/grader_support/run.py
+++ b/grader_support/run.py
@@ -14,8 +14,6 @@ import json
 import random
 import sys
 
-import six
-
 from . import gradelib  # to set the random seed
 from . import graderutil
 

--- a/load_test/run.py
+++ b/load_test/run.py
@@ -34,7 +34,7 @@ def start_mock_xqueue(port):
     return proc
 
 def start_queue_watcher(config_file, codejail_config_file):
-    cmd = 'python -m xqueue_watcher -f {} -j {}'.format(config_file, codejail_config_file)
+    cmd = f'python -m xqueue_watcher -f {config_file} -j {codejail_config_file}'
     print(cmd)
     proc = subprocess.Popen(cmd.split())
     return proc

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,20 +5,13 @@
 #    make upgrade
 #
 -e git+https://github.com/edx/codejail.git@4127fc4bd5775cc72aee8d7f0a70e31405e22439#egg=codejail  # via -r requirements/base.in
-backports.os==0.1.1       # via path.py
-certifi==2020.6.20        # via requests
-chardet==3.0.4            # via requests
-configparser==4.0.2       # via importlib-metadata
-contextlib2==0.6.0.post1  # via importlib-metadata, zipp
+certifi==2020.12.5        # via requests
+chardet==4.0.0            # via requests
 dogstatsd-python==0.5.6   # via -r requirements/base.in
-future==0.18.2            # via backports.os
 idna==2.10                # via requests
-importlib-metadata==1.7.0  # via path.py
-newrelic==5.14.1.144      # via -r requirements/base.in
-path.py==11.5.2           # via -c requirements/constraints.txt, -r requirements/base.in
-pathlib2==2.3.5           # via importlib-metadata
-requests==2.24.0          # via -r requirements/base.in
-scandir==1.10.0           # via pathlib2
-six==1.15.0               # via -r requirements/base.in, pathlib2
-urllib3==1.25.9           # via requests
-zipp==1.2.0               # via importlib-metadata
+newrelic==6.2.0.156       # via -r requirements/base.in
+path.py==12.5.0           # via -r requirements/base.in
+path==15.1.2              # via path.py
+requests==2.25.1          # via -r requirements/base.in
+six==1.15.0               # via -r requirements/base.in
+urllib3==1.26.4           # via requests

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -5,20 +5,13 @@
 #    make upgrade
 #
 -e git+https://github.com/edx/codejail.git@4127fc4bd5775cc72aee8d7f0a70e31405e22439#egg=codejail  # via -r requirements/base.txt
-backports.os==0.1.1       # via -r requirements/base.txt, path.py
-certifi==2020.6.20        # via -r requirements/base.txt, requests
-chardet==3.0.4            # via -r requirements/base.txt, requests
-configparser==4.0.2       # via -r requirements/base.txt, importlib-metadata
-contextlib2==0.6.0.post1  # via -r requirements/base.txt, importlib-metadata, zipp
+certifi==2020.12.5        # via -r requirements/base.txt, requests
+chardet==4.0.0            # via -r requirements/base.txt, requests
 dogstatsd-python==0.5.6   # via -r requirements/base.txt
-future==0.18.2            # via -r requirements/base.txt, backports.os
 idna==2.10                # via -r requirements/base.txt, requests
-importlib-metadata==1.7.0  # via -r requirements/base.txt, path.py
-newrelic==5.14.1.144      # via -r requirements/base.txt
-path.py==11.5.2           # via -c requirements/constraints.txt, -r requirements/base.txt
-pathlib2==2.3.5           # via -r requirements/base.txt, importlib-metadata
-requests==2.24.0          # via -r requirements/base.txt
-scandir==1.10.0           # via -r requirements/base.txt, pathlib2
-six==1.15.0               # via -r requirements/base.txt, pathlib2
-urllib3==1.25.9           # via -r requirements/base.txt, requests
-zipp==1.2.0               # via -r requirements/base.txt, importlib-metadata
+newrelic==6.2.0.156       # via -r requirements/base.txt
+path.py==12.5.0           # via -r requirements/base.txt
+path==15.1.2              # via -r requirements/base.txt, path.py
+requests==2.25.1          # via -r requirements/base.txt
+six==1.15.0               # via -r requirements/base.txt
+urllib3==1.26.4           # via -r requirements/base.txt, requests

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,34 +5,24 @@
 #    make upgrade
 #
 -e git+https://github.com/edx/codejail.git@4127fc4bd5775cc72aee8d7f0a70e31405e22439#egg=codejail  # via -r requirements/production.txt
-atomicwrites==1.4.0       # via pytest
-attrs==19.3.0             # via pytest
-backports.functools-lru-cache==1.6.1  # via wcwidth
-backports.os==0.1.1       # via -r requirements/production.txt, path.py
-certifi==2020.6.20        # via -r requirements/production.txt, requests
-chardet==3.0.4            # via -r requirements/production.txt, requests
-configparser==4.0.2       # via -r requirements/production.txt, importlib-metadata
-contextlib2==0.6.0.post1  # via -r requirements/production.txt, importlib-metadata, zipp
-coverage==5.1             # via pytest-cov
+attrs==20.3.0             # via pytest
+certifi==2020.12.5        # via -r requirements/production.txt, requests
+chardet==4.0.0            # via -r requirements/production.txt, requests
+coverage==5.5             # via pytest-cov
 dogstatsd-python==0.5.6   # via -r requirements/production.txt
-funcsigs==1.0.2           # via mock, pytest
-future==0.18.2            # via -r requirements/production.txt, backports.os
 idna==2.10                # via -r requirements/production.txt, requests
-importlib-metadata==1.7.0  # via -r requirements/production.txt, path.py, pluggy, pytest
-mock==3.0.5               # via -r requirements/test.in
-more-itertools==5.0.0     # via pytest
-newrelic==5.14.1.144      # via -r requirements/production.txt
-packaging==20.4           # via pytest
-path.py==11.5.2           # via -c requirements/constraints.txt, -r requirements/production.txt
-pathlib2==2.3.5           # via -r requirements/production.txt, importlib-metadata, pytest
+iniconfig==1.1.1          # via pytest
+mock==4.0.3               # via -r requirements/test.in
+newrelic==6.2.0.156       # via -r requirements/production.txt
+packaging==20.9           # via pytest
+path.py==12.5.0           # via -r requirements/production.txt
+path==15.1.2              # via -r requirements/production.txt, path.py
 pluggy==0.13.1            # via pytest
-py==1.9.0                 # via pytest
+py==1.10.0                # via pytest
 pyparsing==2.4.7          # via packaging
-pytest-cov==2.10.0        # via -r requirements/test.in
-pytest==4.6.11            # via pytest-cov
-requests==2.24.0          # via -r requirements/production.txt
-scandir==1.10.0           # via -r requirements/production.txt, pathlib2
-six==1.15.0               # via -r requirements/production.txt, mock, more-itertools, packaging, pathlib2, pytest
-urllib3==1.25.9           # via -r requirements/production.txt, requests
-wcwidth==0.2.5            # via pytest
-zipp==1.2.0               # via -r requirements/production.txt, importlib-metadata
+pytest-cov==2.11.1        # via -r requirements/test.in
+pytest==6.2.4             # via pytest-cov
+requests==2.25.1          # via -r requirements/production.txt
+six==1.15.0               # via -r requirements/production.txt
+toml==0.10.2              # via pytest
+urllib3==1.26.4           # via -r requirements/production.txt, requests

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -5,34 +5,24 @@
 #    make upgrade
 #
 -e git+https://github.com/edx/codejail.git@4127fc4bd5775cc72aee8d7f0a70e31405e22439#egg=codejail  # via -r requirements/test.txt
-atomicwrites==1.4.0       # via -r requirements/test.txt, pytest
-attrs==19.3.0             # via -r requirements/test.txt, pytest
-backports.functools-lru-cache==1.6.1  # via -r requirements/test.txt, wcwidth
-backports.os==0.1.1       # via -r requirements/test.txt, path.py
-certifi==2020.6.20        # via -r requirements/test.txt, requests
-chardet==3.0.4            # via -r requirements/test.txt, requests
-configparser==4.0.2       # via -r requirements/test.txt, importlib-metadata
-contextlib2==0.6.0.post1  # via -r requirements/test.txt, importlib-metadata, zipp
-coverage==5.1             # via -r requirements/test.txt, -r requirements/travis.in, pytest-cov
+attrs==20.3.0             # via -r requirements/test.txt, pytest
+certifi==2020.12.5        # via -r requirements/test.txt, requests
+chardet==4.0.0            # via -r requirements/test.txt, requests
+coverage==5.5             # via -r requirements/test.txt, -r requirements/travis.in, pytest-cov
 dogstatsd-python==0.5.6   # via -r requirements/test.txt
-funcsigs==1.0.2           # via -r requirements/test.txt, mock, pytest
-future==0.18.2            # via -r requirements/test.txt, backports.os
 idna==2.10                # via -r requirements/test.txt, requests
-importlib-metadata==1.7.0  # via -r requirements/test.txt, path.py, pluggy, pytest
-mock==3.0.5               # via -r requirements/test.txt
-more-itertools==5.0.0     # via -r requirements/test.txt, pytest
-newrelic==5.14.1.144      # via -r requirements/test.txt
-packaging==20.4           # via -r requirements/test.txt, pytest
-path.py==11.5.2           # via -c requirements/constraints.txt, -r requirements/test.txt
-pathlib2==2.3.5           # via -r requirements/test.txt, importlib-metadata, pytest
+iniconfig==1.1.1          # via -r requirements/test.txt, pytest
+mock==4.0.3               # via -r requirements/test.txt
+newrelic==6.2.0.156       # via -r requirements/test.txt
+packaging==20.9           # via -r requirements/test.txt, pytest
+path.py==12.5.0           # via -r requirements/test.txt
+path==15.1.2              # via -r requirements/test.txt, path.py
 pluggy==0.13.1            # via -r requirements/test.txt, pytest
-py==1.9.0                 # via -r requirements/test.txt, pytest
+py==1.10.0                # via -r requirements/test.txt, pytest
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
-pytest-cov==2.10.0        # via -r requirements/test.txt
-pytest==4.6.11            # via -r requirements/test.txt, pytest-cov
-requests==2.24.0          # via -r requirements/test.txt
-scandir==1.10.0           # via -r requirements/test.txt, pathlib2
-six==1.15.0               # via -r requirements/test.txt, mock, more-itertools, packaging, pathlib2, pytest
-urllib3==1.25.9           # via -r requirements/test.txt, requests
-wcwidth==0.2.5            # via -r requirements/test.txt, pytest
-zipp==1.2.0               # via -r requirements/test.txt, importlib-metadata
+pytest-cov==2.11.1        # via -r requirements/test.txt
+pytest==6.2.4             # via -r requirements/test.txt, pytest-cov
+requests==2.25.1          # via -r requirements/test.txt
+six==1.15.0               # via -r requirements/test.txt
+toml==0.10.2              # via -r requirements/test.txt, pytest
+urllib3==1.26.4           # via -r requirements/test.txt, requests

--- a/tests/test_grader.py
+++ b/tests/test_grader.py
@@ -1,9 +1,9 @@
 import unittest
-import mock
+from unittest import mock
 import json
 import sys
 from path import Path
-from six.moves.queue import Queue
+from queue import Queue
 
 from xqueue_watcher import grader
 

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1,7 +1,7 @@
 import unittest
 from path import Path
 import json
-from mock import Mock
+from unittest.mock import Mock
 import time
 import sys
 
@@ -9,7 +9,7 @@ import logging
 from xqueue_watcher import manager
 from tests.test_xqueue_client import MockXQueueServer
 
-from six import StringIO
+from io import StringIO
 
 try:
     import codejail

--- a/tests/test_xqueue_client.py
+++ b/tests/test_xqueue_client.py
@@ -1,5 +1,5 @@
 import unittest
-import mock
+from unittest import mock
 import json
 import collections
 import requests

--- a/xqueue_watcher/client.py
+++ b/xqueue_watcher/client.py
@@ -41,7 +41,7 @@ class XQueueClient:
         self.processing = False
 
     def __repr__(self):
-        return '{}({})'.format(self.__class__.__name__, self.queue_name)
+        return f'{self.__class__.__name__}({self.queue_name})'
 
     def _parse_response(self, response, is_reply=True):
         if response.status_code not in [200]:
@@ -106,7 +106,7 @@ class XQueueClient:
         if self.username is None:
             return True
         url = self.xqueue_server + '/xqueue/login/'
-        log.debug("Trying to login to {} with user: {} and pass {}".format(url, self.username, self.password))
+        log.debug(f"Trying to login to {url} with user: {self.username} and pass {self.password}")
         response = self.session.request('post', url, auth=self.http_basic_auth, data={
             'username': self.username,
             'password': self.password,

--- a/xqueue_watcher/grader.py
+++ b/xqueue_watcher/grader.py
@@ -17,9 +17,9 @@ def format_errors(errors):
     error_string = ''
     error_list = [esc(e) for e in errors or []]
     if error_list:
-        items = '\n'.join(['<li><pre>{}</pre></li>\n'.format(e) for e in error_list])
-        error_string = '<ul>\n{}</ul>\n'.format(items)
-        error_string = '<div class="result-errors">{}</div>'.format(error_string)
+        items = '\n'.join([f'<li><pre>{e}</pre></li>\n' for e in error_list])
+        error_string = f'<ul>\n{items}</ul>\n'
+        error_string = f'<div class="result-errors">{error_string}</div>'
     return error_string
 
 
@@ -126,10 +126,10 @@ class Grader:
                 # However, for debugging, still want to see what the problem is
                 statsd.increment('xqueuewatcher.grader_payload_error')
 
-                self.log.debug("error parsing: '{}' -- {}".format(payload, err))
+                self.log.debug(f"error parsing: '{payload}' -- {err}")
                 raise
 
-            self.log.debug("Processing submission, grader payload: {}".format(payload))
+            self.log.debug(f"Processing submission, grader payload: {payload}")
             relative_grader_path = grader_config['grader']
             grader_path = (self.grader_root / relative_grader_path).abspath()
             start = time.time()


### PR DESCRIPTION
**Issue:** [BOM-2474](https://openedx.atlassian.net/browse/BOM-2474)

## Description
- Ran pyupgrade on the repo to upgrade the code to `Python 3.8` syntax.
- Removed tests for `Python 3.5`.
- Related PR: https://github.com/edx/configuration/pull/6396